### PR TITLE
Create new `SegmentedControl` element

### DIFF
--- a/src/elements/SegmentedControl.ts
+++ b/src/elements/SegmentedControl.ts
@@ -3,24 +3,24 @@ import { Input } from './Input';
 
 import { SupportedTypes } from '../options/configuration';
 
-interface Segment {
-	id: string;
+interface Segment<T> {
+	id: T;
 	// TODO: am i able to make this a generic class, and make getInstance play nicely?
 	value: SupportedTypes;
 	default: boolean;
 	showDependents: boolean;
 }
 
-type Segments = (
-	Segment & {
+type Segments<T> = (
+	Segment<T> & {
 		input: Input;
 	}
 )[];
 
 export class SegmentedControl extends Element {
-	private segments: Segments;
+	private segments: Segments<string>;
 
-	private constructor(id: string, type = 'segmented control', segments: Segment[]) {
+	private constructor(id: string, type = 'segmented control', segments: Segment<string>[]) {
 		super(id, type);
 
 		this.segments = segments.map(segment => ({
@@ -29,7 +29,7 @@ export class SegmentedControl extends Element {
 		}));
 	}
 
-	public static override getInstance<T extends string>(id: T, type = 'segmented control', segments?: Segment[]): SegmentedControl {
+	public static override getInstance<T extends string>(id: T, type = 'segmented control', segments?: Segment<T>[]): SegmentedControl {
 		if (!segments) throw new Error(`You must declare the segments for this SegmentedControl ${id}!`);
 
 		return SegmentedControl.instances[id] = (SegmentedControl.instances[id] instanceof SegmentedControl)

--- a/src/elements/SegmentedControl.ts
+++ b/src/elements/SegmentedControl.ts
@@ -1,15 +1,103 @@
 import { Element } from './Element';
+import { Input } from './Input';
 
 import { SupportedTypes } from '../options/configuration';
-import { InputFieldValidator } from '../options/validator';
+
+interface Segment {
+	id: string;
+	// TODO: am i able to make this a generic class, and make getInstance play nicely?
+	value: SupportedTypes;
+	default: boolean;
+	showDependents: boolean;
+}
+
+type Segments = (
+	Segment & {
+		input: Input;
+	}
+)[];
 
 export class SegmentedControl extends Element {
-	getValue(): SupportedTypes;
-	validate(force?: boolean): Promise<SupportedTypes | typeof InputFieldValidator.INVALID_INPUT>;
-	setValue(value: SupportedTypes, dispatchEvent?: boolean): void;
-	show(): void;
-	hide(): void;
-	toggleDependents(dependents: readonly string[]): void;
-	addEventListener(...args: Parameters<typeof HTMLElement.prototype.addEventListener>): void;
-	dispatchInputEvent(bubbles?: boolean): void;
+	private segments: Segments;
+
+	private constructor(id: string, type = 'segmented control', segments: Segment[]) {
+		super(id, type);
+
+		this.segments = segments.map(segment => ({
+			...segment,
+			input: Input.getInstance(segment.id, 'segmented control input'),
+		}));
+	}
+
+	public static override getInstance<T extends string>(id: T, type = 'segmented control', segments?: Segment[]): SegmentedControl {
+		if (!segments) throw new Error(`You must declare the segments for this SegmentedControl ${id}!`);
+
+		return SegmentedControl.instances[id] = (SegmentedControl.instances[id] instanceof SegmentedControl)
+			? <SegmentedControl>SegmentedControl.instances[id]
+			: new SegmentedControl(id, type, segments);
+	}
+
+	public async validate() {
+		return await this.getValue();
+	}
+
+	private getCheckedSegment() {
+		return this.element.querySelector('input:checked');
+	}
+
+	public getValue(): SupportedTypes {
+		const checkedSegment = this.getCheckedSegment();
+
+		if (!checkedSegment) return this.segments.find(segment => Boolean(segment.default))?.value ?? null;
+
+		return this.segments.find(({ id }) => id === checkedSegment.id)?.value ?? null;
+	}
+
+	// TODO: see generics above
+	public setValue(value: SupportedTypes, dispatchEvent = true) {
+		const segmentToCheck = this.segments.find(segment => segment.value === value);
+
+		if (!segmentToCheck) throw new Error(`Failed to set unexpected value ${value} of type ${typeof value} on segmented control ${this.id}`);
+
+		segmentToCheck.input.setValue(true);
+
+		if (!dispatchEvent) return;
+		this.dispatchInputEvent();
+	}
+
+	public override show() {
+		super.show();
+		this.dispatchInputEvent();
+	}
+
+	public override hide() {
+		super.hide();
+		this.dispatchInputEvent();
+	}
+
+	public dispatchInputEvent(bubbles?: boolean) {
+		this.dispatchEvent(new Event('input', { bubbles }));
+	}
+
+	public toggleDependents(dependents: readonly string[]) {
+		const checkedSegment = this.getCheckedSegment();
+
+		const showDependents = this.segments.find(({ id }) => id === checkedSegment?.id)?.showDependents;
+
+		if (!checkedSegment || this.isHidden() || !showDependents) {
+			dependents.forEach(dependentId => {
+				const dependent = Element.getInstance(dependentId, 'dependent');
+				dependent.hide();
+				dependent.dispatchEvent(new Event('input', { bubbles: true }));
+			});
+
+			return;
+		}
+
+		dependents.forEach(dependentId => {
+			const dependent = Element.getInstance(dependentId, 'dependent');
+			dependent.show();
+			dependent.dispatchEvent(new Event('input', { bubbles: true }));
+		});
+	}
 }

--- a/src/elements/SegmentedControl.ts
+++ b/src/elements/SegmentedControl.ts
@@ -3,24 +3,23 @@ import { Input } from './Input';
 
 import { SupportedTypes } from '../options/configuration';
 
-interface Segment<T> {
+interface Segment<T, V> {
 	id: T;
-	// TODO: am i able to make this a generic class, and make getInstance play nicely?
-	value: SupportedTypes;
+	value: V;
 	default?: boolean;
 	showDependents?: boolean;
 }
 
-type Segments<T> = (
-	Segment<T> & {
+type Segments<T, V> = (
+	Segment<T, V> & {
 		input: Input;
 	}
 )[];
 
 export class SegmentedControl extends Element {
-	private segments: Segments<string>;
+	private segments: Segments<string, SupportedTypes>;
 
-	private constructor(id: string, type = 'segmented control', segments: Segment<string>[]) {
+	private constructor(id: string, type = 'segmented control', segments: Segment<string, SupportedTypes>[]) {
 		super(id, type);
 
 		this.segments = segments.map(segment => ({
@@ -29,7 +28,7 @@ export class SegmentedControl extends Element {
 		}));
 	}
 
-	public static override getInstance<T extends string>(id: T, type = 'segmented control', segments?: Segment<T>[]): SegmentedControl {
+	public static override getInstance<T extends string, V extends SupportedTypes>(id: T, type = 'segmented control', segments?: Segment<T, V>[]): SegmentedControl {
 		if (!segments) throw new Error(`You must declare the segments for this SegmentedControl ${id}!`);
 
 		return SegmentedControl.instances[id] = (SegmentedControl.instances[id] instanceof SegmentedControl)
@@ -53,7 +52,6 @@ export class SegmentedControl extends Element {
 		return this.segments.find(({ id }) => id === checkedSegment.id)?.value ?? null;
 	}
 
-	// TODO: see generics above
 	public setValue(value: SupportedTypes, dispatchEvent = true) {
 		const segmentToCheck = this.segments.find(segment => segment.value === value);
 

--- a/src/elements/SegmentedControl.ts
+++ b/src/elements/SegmentedControl.ts
@@ -7,8 +7,8 @@ interface Segment<T> {
 	id: T;
 	// TODO: am i able to make this a generic class, and make getInstance play nicely?
 	value: SupportedTypes;
-	default: boolean;
-	showDependents: boolean;
+	default?: boolean;
+	showDependents?: boolean;
 }
 
 type Segments<T> = (

--- a/src/elements/SegmentedControl.ts
+++ b/src/elements/SegmentedControl.ts
@@ -59,7 +59,7 @@ export class SegmentedControl extends Element {
 
 		if (!segmentToCheck) throw new Error(`Failed to set unexpected value ${value} of type ${typeof value} on segmented control ${this.id}`);
 
-		segmentToCheck.input.setValue(true);
+		segmentToCheck.input.setValue(true, false);
 
 		if (!dispatchEvent) return;
 		this.dispatchInputEvent();

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -3,6 +3,7 @@ export { Button } from './Button';
 export { Input } from './Input';
 export { Select } from './Select';
 export { KeyValueGroup } from './KeyValueGroup';
+export { SegmentedControl } from './SegmentedControl';
 
 export function getElementById<T extends string>(id: T): HTMLElement | null {
 	return document.getElementById(id);

--- a/src/options/configuration.ts
+++ b/src/options/configuration.ts
@@ -143,7 +143,7 @@ export const CONFIGURATION: {
 				defaultValue: 'SYSTEM',
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = SegmentedControl.getInstance<InputElementId>('display-theme', 'segmented control', [
+					return this.input = SegmentedControl.getInstance<InputElementId, typeof this.defaultValue>('display-theme', 'segmented control', [
 						{
 							id: 'display-system-mode',
 							value: 'SYSTEM',
@@ -166,7 +166,7 @@ export const CONFIGURATION: {
 				defaultValue: false,
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = SegmentedControl.getInstance<InputElementId>('display-json-button', 'segmented control', [
+					return this.input = SegmentedControl.getInstance<InputElementId, typeof this.defaultValue>('display-json-button', 'segmented control', [
 						{
 							id: 'hide-json-button',
 							value: false,
@@ -186,7 +186,7 @@ export const CONFIGURATION: {
 				defaultValue: false,
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = SegmentedControl.getInstance<InputElementId>('display-advanced-options', 'segmented control', [
+					return this.input = SegmentedControl.getInstance<InputElementId, typeof this.defaultValue>('display-advanced-options', 'segmented control', [
 						{
 							id: 'hide-advanced-options',
 							value: false,

--- a/src/options/configuration.ts
+++ b/src/options/configuration.ts
@@ -146,7 +146,7 @@ export const CONFIGURATION: {
 				defaultValue: false,
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = Input.getInstance<InputElementId>('show-json-button', 'input');
+					return this.input = SegmentedControl.getInstance<InputElementId>('show-json-button', 'input');
 				},
 			},
 		},
@@ -155,7 +155,7 @@ export const CONFIGURATION: {
 				defaultValue: false,
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = Input.getInstance<InputElementId>('show-advanced-options', 'input');
+					return this.input = SegmentedControl.getInstance<InputElementId>('show-advanced-options', 'input');
 				},
 			},
 		},

--- a/src/options/configuration.ts
+++ b/src/options/configuration.ts
@@ -69,8 +69,15 @@ type IncompleteFieldKey<K extends string> = K extends keyof SavedFields
 interface InputElements {
 	'timeZone': 'timezone';
 	'extension.displayTheme': 'display-theme';
-	'popup.displayJSONButton': 'show-json-button';
-	'options.displayAdvanced': 'show-advanced-options';
+	displaySystemMode: 'display-system-mode';
+	displayLightMode: 'display-light-mode';
+	displayDarkMode: 'display-dark-mode';
+	'popup.displayJSONButton': 'display-json-button';
+	hideJSONButton: 'hide-json-button';
+	showJSONButton: 'show-json-button';
+	'options.displayAdvanced': 'display-advanced-options';
+	hideAdvancedOptions: 'hide-advanced-options';
+	showAdvancedOptions: 'show-advanced-options';
 	'canvas.classNames.breadcrumbs': 'breadcrumbs';
 	'canvas.classNames.assignment': 'assignment-class';
 	'canvas.classNames.title': 'assignment-title';
@@ -137,7 +144,21 @@ export const CONFIGURATION: {
 				defaultValue: 'SYSTEM',
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = SegmentedControl.getInstance<InputElementId>('display-theme', 'input');
+					return this.input = SegmentedControl.getInstance<InputElementId>('display-theme', 'segmented control', [
+						{
+							id: 'display-system-mode',
+							value: 'SYSTEM',
+							default: true,
+						},
+						{
+							id: 'display-light-mode',
+							value: 'LIGHT',
+						},
+						{
+							id: 'display-dark-mode',
+							value: 'DARK',
+						},
+					]);
 				},
 			},
 		},
@@ -146,7 +167,18 @@ export const CONFIGURATION: {
 				defaultValue: false,
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = SegmentedControl.getInstance<InputElementId>('show-json-button', 'input');
+					return this.input = SegmentedControl.getInstance<InputElementId>('display-json-button', 'segmented control', [
+						{
+							id: 'hide-json-button',
+							value: false,
+							default: true,
+						},
+						{
+							id: 'show-json-button',
+							value: true,
+							showDependents: true,
+						},
+					]);
 				},
 			},
 		},
@@ -155,7 +187,18 @@ export const CONFIGURATION: {
 				defaultValue: false,
 				get input() {
 					delete (<Partial<typeof this>>this).input;
-					return this.input = SegmentedControl.getInstance<InputElementId>('show-advanced-options', 'input');
+					return this.input = SegmentedControl.getInstance<InputElementId>('display-advanced-options', 'segmented control', [
+						{
+							id: 'hide-advanced-options',
+							value: false,
+							default: true,
+						},
+						{
+							id: 'show-advanced-options',
+							value: true,
+							showDependents: true,
+						},
+					]);
 				},
 			},
 		},

--- a/src/options/configuration.ts
+++ b/src/options/configuration.ts
@@ -1,4 +1,4 @@
-import { Input, KeyValueGroup } from '../elements';
+import { Input, KeyValueGroup, SegmentedControl } from '../elements';
 
 import { NullIfEmpty, SavedFields, SavedOptions } from './';
 import {
@@ -12,7 +12,6 @@ import {
 } from './validator';
 
 import { valueof } from '../types/utils';
-import { SegmentedControl } from '../elements/SegmentedControl';
 
 export type SupportedTypes = NullIfEmpty<string> | boolean;
 

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -44,8 +44,6 @@ interface OptionsElements {
 	};
 	elements: {
 		advancedOptions: 'advanced-options';
-		advancedOptionsSegmentedControl: 'display-advanced-options';
-		advancedOptionsHide: 'hide-advanced-options';
 		courseCodesGroup: 'course-code-overrides-group';
 		courseCodesCanvas: 'course-code-overrides-canvas';
 		courseCodesNotion: 'course-code-overrides-notion';
@@ -171,27 +169,24 @@ const OptionsPage = <const>{
 
 const AdvancedOptions = <const>{
 	element: Element.getInstance<OptionsElementId>('advanced-options', 'advanced options'),
-	control: Element.getInstance<OptionsElementId>('display-advanced-options', 'advanced options control'),
-	showInput: CONFIGURATION.FIELDS['options.displayAdvanced'].input,
-	hideInput: Input.getInstance<OptionsElementId>('hide-advanced-options'),
+	control: CONFIGURATION.FIELDS['options.displayAdvanced'].input,
 
 	show() {
-		this.element.removeClass('hidden');
+		this.element.show();
 	},
 
 	hide() {
-		this.element.addClass('hidden');
-		this.hideInput.setValue(true, false);
+		this.element.hide();
 	},
 
-	toggle(display: boolean) {
-		(display)
+	toggle() {
+		(this.control.getValue())
 			? this.show()
 			: this.hide();
 	},
 
 	dispatchInputEvent() {
-		this.control.dispatchEvent(new Event('input', { bubbles: true }));
+		this.control.dispatchInputEvent();
 	},
 };
 
@@ -433,9 +428,6 @@ const buttons: {
 	},
 };
 
-// show advanced options if appropriate
-Storage.getOptions().then(({ options: { displayAdvanced } }) => AdvancedOptions.toggle(displayAdvanced));
-
 // toggle dependents if appropriate
 Object.values(CONFIGURATION.FIELDS).forEach(({ input, dependents }) => {
 	if (!dependents) return;
@@ -478,15 +470,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 	await OptionsPage.restoreOptions();
 
 	Object.values(buttons.restore).forEach(button => button.toggle());
+
+	// show advanced options if appropriate
+	AdvancedOptions.toggle();
 });
 
 // add event listener to advanced options toggle
-AdvancedOptions.control?.addEventListener('input', () => {
-	AdvancedOptions.toggle(Boolean(AdvancedOptions.showInput.getValue()));
-
-	AdvancedOptions.showInput.dispatchInputEvent(false);
-	AdvancedOptions.hideInput.dispatchInputEvent(false);
-});
+AdvancedOptions.control?.addEventListener('input', AdvancedOptions.toggle.bind(AdvancedOptions));
 
 // validate fields on input
 Object.values(CONFIGURATION.FIELDS)
@@ -567,10 +557,10 @@ const Konami = {
 
 		this.currentIndex++;
 
-		if (this.currentIndex !== this.pattern.length || !AdvancedOptions.control) return;
+		if (this.currentIndex !== this.pattern.length) return;
 
 		this.currentIndex = 0;
-		AdvancedOptions.showInput.setValue(true);
+		AdvancedOptions.control.setValue(true);
 	},
 };
 


### PR DESCRIPTION
Creates a new `SegmentedControl` element that supports the full breadth of `SupportedTypes` as values, as well as multiple segments.

This is in contrast to the existing segmented control implementation, which only supports a `true`/`false` bi-segmented input.