### PR TITLE
Use `Map` class for performance improvement

### DIFF
--- a/src/elements/Button.ts
+++ b/src/elements/Button.ts
@@ -16,9 +16,11 @@ export class Button extends Element {
 	}
 
 	public static override getInstance<T extends string>(id: T): Button {
-		return Button.instances[id] = (Button.instances[id] instanceof Button)
-			? <Button>Button.instances[id]
-			: new Button(id);
+		if (!(Button.instances.get(id) instanceof Button)) {
+			Button.instances.set(id, new Button(id));
+		}
+
+		return <Button>Button.instances.get(id);
 	}
 
 	public setDefaultLabel(html: string) {

--- a/src/elements/Element.ts
+++ b/src/elements/Element.ts
@@ -1,8 +1,8 @@
 export class Element {
-	protected static instances: Record<string, Element> = {};
+	protected static instances = new Map<string, Element>();
 
 	protected element: HTMLElement;
-	private timeouts: Record<string, ReturnType<typeof setTimeout>> = {};
+	private timeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
 	private tile?: HTMLElement | false;
 	private parentHeading?: HTMLHeadingElement | false;
@@ -15,7 +15,11 @@ export class Element {
 	}
 
 	public static getInstance<T extends string>(id: T, type: string): Element {
-		return Element.instances[id] ??= new Element(id, type);
+		if (!Element.instances.has(id)) {
+			Element.instances.set(id, new Element(id, type));
+		}
+
+		return <Element>Element.instances.get(id);
 	}
 
 	public get id() {
@@ -28,7 +32,7 @@ export class Element {
 
 	public remove() {
 		this.element.remove();
-		delete Element.instances[this.id];
+		Element.instances.delete(this.id);
 	}
 
 	public addClass(className: string) {
@@ -170,12 +174,12 @@ export class Element {
 	}
 
 	public setTimeout(name: string, timeout: () => void, delay: number) {
-		clearTimeout(this.timeouts[name]);
-		this.timeouts[name] = setTimeout(timeout, delay);
+		clearTimeout(this.timeouts.get(name));
+		this.timeouts.set(name, setTimeout(timeout, delay));
 	}
 
 	public clearTimeout(name: string) {
-		clearTimeout(this.timeouts[name]);
+		clearTimeout(this.timeouts.get(name));
 	}
 
 	public dispatchEvent(event: Event) {

--- a/src/elements/Input.ts
+++ b/src/elements/Input.ts
@@ -22,9 +22,11 @@ export class Input extends Element {
 	}
 
 	public static override getInstance<T extends string>(id: T, type = 'input', Validator?: ValidatorConstructor): Input {
-		return Input.instances[id] = (Input.instances[id] instanceof Input)
-			? <Input>Input.instances[id]
-			: new Input(id, type, Validator);
+		if (!(Input.instances.get(id) instanceof Input)) {
+			Input.instances.set(id, new Input(id, type, Validator));
+		}
+
+		return <Input>Input.instances.get(id);
 	}
 
 	private static isValid(element: HTMLElement | null): element is HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {

--- a/src/elements/KeyValueGroup.ts
+++ b/src/elements/KeyValueGroup.ts
@@ -46,9 +46,11 @@ export class KeyValueGroup extends Element {
 	}
 
 	public static override getInstance<T extends string>(id: T): KeyValueGroup {
-		return KeyValueGroup.instances[id] = (KeyValueGroup.instances[id] instanceof KeyValueGroup)
-			? <KeyValueGroup>KeyValueGroup.instances[id]
-			: new KeyValueGroup(id);
+		if (!(KeyValueGroup.instances.get(id) instanceof KeyValueGroup)) {
+			KeyValueGroup.instances.set(id, new KeyValueGroup(id));
+		}
+
+		return <KeyValueGroup>KeyValueGroup.instances.get(id);
 	}
 
 	public get isValidating() {

--- a/src/elements/SegmentedControl.ts
+++ b/src/elements/SegmentedControl.ts
@@ -31,9 +31,11 @@ export class SegmentedControl extends Element {
 	public static override getInstance<T extends string, V extends SupportedTypes>(id: T, type = 'segmented control', segments?: Segment<T, V>[]): SegmentedControl {
 		if (!segments) throw new Error(`You must declare the segments for this SegmentedControl ${id}!`);
 
-		return SegmentedControl.instances[id] = (SegmentedControl.instances[id] instanceof SegmentedControl)
-			? <SegmentedControl>SegmentedControl.instances[id]
-			: new SegmentedControl(id, type, segments);
+		if (!(SegmentedControl.instances.get(id) instanceof SegmentedControl)) {
+			SegmentedControl.instances.set(id, new SegmentedControl(id, type, segments));
+		}
+
+		return <SegmentedControl>SegmentedControl.instances.get(id);
 	}
 
 	public async validate() {

--- a/src/elements/Select.ts
+++ b/src/elements/Select.ts
@@ -6,9 +6,11 @@ export class Select extends Input {
 	}
 
 	public static override getInstance<T extends string>(id: T): Select {
-		return Select.instances[id] = (Select.instances[id] instanceof Select)
-			? <Select>Select.instances[id]
-			: new Select(id);
+		if (!(Select.instances.get(id) instanceof Select)) {
+			Select.instances.set(id, new Select(id));
+		}
+
+		return <Select>Select.instances.get(id);
 	}
 
 	public setInnerHTML(html: string) {

--- a/src/options/PropertySelects.ts
+++ b/src/options/PropertySelects.ts
@@ -1,0 +1,128 @@
+import { GetDatabaseResponse } from '@notionhq/client/build/src/api-endpoints';
+import { NotionClient } from '../apis/notion';
+import { Storage } from '../apis/storage';
+
+import { SavedFields } from '.';
+import { CONFIGURATION, SupportedTypes } from './configuration';
+
+import { Select } from '../elements';
+
+import { valueof } from '../types/utils';
+
+export class PropertySelect extends Select {
+	private type: valueof<GetDatabaseResponse['properties']>['type'];
+	protected fieldKey: keyof SavedFields;
+
+	protected constructor(id: string, type: PropertySelect['type'], fieldKey: PropertySelect['fieldKey']) {
+		super(id);
+
+		this.type = type;
+		this.fieldKey = fieldKey;
+	}
+
+	public static override getInstance<T extends string>(id: T, type?: PropertySelect['type'], fieldKey?: PropertySelect['fieldKey']): PropertySelect {
+		if (!type) throw new Error('Argument type must be defined for class PropertySelect!');
+		if (!fieldKey) throw new Error('Argument fieldKey must be defined for class PropertySelect!');
+
+		if (!(PropertySelect.instances.get(id) instanceof PropertySelect)) {
+			PropertySelect.instances.set(id, new PropertySelect(id, type, fieldKey));
+		}
+
+		return <PropertySelect>PropertySelect.instances.get(id);
+	}
+
+	public async populate(databasePromise: Promise<void | GetDatabaseResponse>, placeholder = 'Loading') {
+		this.setInnerHTML(`<option selected disabled hidden>${placeholder}...</option>`);
+
+		const database = await databasePromise;
+		if (!database) return;
+
+		const configured = (await Storage.getSavedFields())[this.fieldKey];
+
+		const selectOptions = Object.values(database.properties)
+			.filter(({ type }) => type === this.type)
+			.reduce((html: string, { name }) => html + `
+			<option value='${name}' ${(configured === name) ? 'selected' : ''}>
+				${name}
+			</option>
+			`, (!(this.element instanceof HTMLSelectElement) || !this.element.required)
+				? `
+				<option value=''>❌ Exclude</option>
+				`
+				: '',
+			);
+
+		this.setInnerHTML(selectOptions ?? '');
+
+		this.dispatchInputEvent();
+	}
+}
+
+export class SelectPropertyValueSelect extends PropertySelect {
+	private propertySelect: PropertySelect;
+
+	protected constructor(id: string, type: PropertySelect['type'], fieldKey: PropertySelect['fieldKey'], getDatabaseId: () => SupportedTypes, propertySelect: PropertySelect) {
+		super(id, type, fieldKey);
+
+		this.propertySelect = propertySelect;
+
+		this.propertySelect.addEventListener('input', async () => {
+			const databaseId = getDatabaseId();
+			if (typeof databaseId !== 'string') return;
+
+			const accessToken = (await Storage.getNotionAuthorisation()).accessToken ?? await CONFIGURATION.FIELDS['notion.accessToken'].input.validate(true);
+
+			if (!accessToken || typeof accessToken !== 'string') return;
+
+			const databasePromise = NotionClient.getInstance({ auth: accessToken }).retrieveDatabase(databaseId);
+
+			this.populate(databasePromise);
+		});
+	}
+
+	public static override getInstance<T extends string>(id: T, type?: PropertySelect['type'], fieldKey?: PropertySelect['fieldKey'], getDatabaseId?: () => SupportedTypes, propertySelect?: PropertySelect): PropertySelect {
+		if (!type) throw new Error('Argument type must be defined for class SelectPropertyValueSelect!');
+		if (!fieldKey) throw new Error('Argument fieldKey must be defined for class SelectPropertyValueSelect!');
+		if (!getDatabaseId) throw new Error('Argument getDatabaseId must be defined for class SelectPropertyValueSelect!');
+		if (!propertySelect) throw new Error('Argument propertySelect must be defined for class SelectPropertyValueSelect!');
+
+		if (!(SelectPropertyValueSelect.instances.get(id) instanceof SelectPropertyValueSelect)) {
+			SelectPropertyValueSelect.instances.set(id, new SelectPropertyValueSelect(id, type, fieldKey, getDatabaseId, propertySelect));
+		}
+
+		return <SelectPropertyValueSelect>SelectPropertyValueSelect.instances.get(id);
+	}
+
+	public override async populate(databasePromise: Promise<void | GetDatabaseResponse>, placeholder = 'Loading') {
+		this.setInnerHTML(`<option selected disabled hidden>${placeholder}...</option>`);
+
+		const database = await databasePromise;
+		if (!database) return;
+
+		const propertyName = this.propertySelect.getValue();
+
+		if (typeof propertyName !== 'string') return;
+
+		const configured = (await Storage.getSavedFields())[this.fieldKey];
+
+		const property = Object.values(database.properties)
+			.find(({ name, type }) => name === propertyName && type === 'select');
+
+		if (!property || !('select' in property)) return;
+
+		const selectOptions = property.select.options.reduce((html: string, { name }) => html + `
+			<option value='${name}' ${(configured === name) ? 'selected' : ''}>
+				${name}
+			</option>
+			`, (!(this.element instanceof HTMLSelectElement) || !this.element.required)
+			? `
+				<option value=''>❌ Exclude</option>
+				`
+			: '',
+		);
+
+		this.setInnerHTML(selectOptions ?? '');
+
+		this.dispatchInputEvent();
+	}
+}

--- a/src/options/RestoreButtons.ts
+++ b/src/options/RestoreButtons.ts
@@ -1,0 +1,92 @@
+import { Storage } from '../apis/storage';
+
+import { SavedFields } from './';
+import { CONFIGURATION, OptionConfiguration, SupportedTypes } from './configuration';
+
+import { Button } from '../elements';
+
+export class RestoreDefaultsButton extends Button {
+	protected restoreKeys: (keyof SavedFields)[];
+	protected inputs: Map<keyof SavedFields, OptionConfiguration<SupportedTypes>['input']>;
+
+	protected constructor(id: string, restoreKeys: (keyof SavedFields)[]) {
+		super(id);
+
+		this.restoreKeys = restoreKeys;
+		this.inputs = new Map(
+			this.restoreKeys.map(key => [key, CONFIGURATION.FIELDS[key].input]),
+		);
+
+		[...this.inputs.values()].forEach(input => input.addEventListener('input', this.toggle.bind(this)));
+	}
+
+	public static override getInstance<T extends string>(id: T, restoreKeys?: (keyof SavedFields)[]): RestoreDefaultsButton {
+		if (!restoreKeys) throw new Error('Argument restoreKeys must be defined for class RestoreDefaultsButton!');
+
+		if (!(RestoreDefaultsButton.instances.get(id) instanceof RestoreDefaultsButton)) {
+			RestoreDefaultsButton.instances.set(id, new this(id, restoreKeys));
+		}
+
+		return <RestoreDefaultsButton>RestoreDefaultsButton.instances.get(id);
+	}
+
+	public toggle() {
+		([...this.inputs].some(([key, input]) => !input.isHidden() && input.getValue() !== CONFIGURATION.FIELDS[<keyof SavedFields>key].defaultValue))
+			? this.show()
+			: this.hide();
+	}
+
+	protected async restoreInputs() {
+		[...this.inputs].forEach(([key, input]) => {
+			const { defaultValue } = CONFIGURATION.FIELDS[<keyof SavedFields>key];
+			input.setValue(defaultValue);
+		});
+	}
+
+	public async restore() {
+		this.restoreInputs();
+		this.toggle();
+	}
+}
+
+export class RestoreSavedButton extends RestoreDefaultsButton {
+	private restoreOptions: () => Promise<void>;
+
+	protected constructor(id: string, restoreKeys: (keyof SavedFields)[], restoreOptions: () => Promise<void>) {
+		super(id, restoreKeys);
+
+		this.restoreOptions = restoreOptions;
+	}
+
+	public static override getInstance<T extends string>(id: T, restoreKeys?: (keyof SavedFields)[], restoreOptions?: () => Promise<void>): RestoreDefaultsButton {
+		if (!restoreKeys) throw new Error('Argument restoreKeys must be defined for class RestoreSavedButton!');
+		if (!restoreOptions) throw new Error('Argument restoreOptions must be defined for class RestoreSavedButton!');
+
+		if (!(RestoreSavedButton.instances.get(id) instanceof RestoreSavedButton)) {
+			RestoreSavedButton.instances.set(id, new this(id, restoreKeys, restoreOptions));
+		}
+
+		return <RestoreSavedButton>RestoreSavedButton.instances.get(id);
+	}
+
+	public override async toggle() {
+		const savedFields = await Storage.getSavedFields();
+
+		const anyUnsavedInputs = [...this.inputs]
+			.reduce((hasUnsaved, [key, input]) => {
+				const isUnsaved = input.markModified(savedFields[<keyof SavedFields>key]);
+
+				return hasUnsaved || isUnsaved;
+			}, false);
+
+		(anyUnsavedInputs)
+			? this.show()
+			: this.hide();
+	}
+
+	protected override async restoreInputs() {
+		await this.restoreOptions();
+
+		[...this.inputs.values()].forEach(input => input.dispatchInputEvent());
+	}
+}


### PR DESCRIPTION
Refactors to replace use of standard `Object`s with the `Map` object.

Was previously using it in *some* cases, this is just refactoring to use it in all applicable instances.

Also moves classes from `options.ts` to their own files.
> (included in this PR as I forgot to switch back to `main` 🙃)