### PR TITLE
Add option to either import or ignore Canvas assignments without a set `due_at` date

### DIFF
--- a/src/apis/storage.ts
+++ b/src/apis/storage.ts
@@ -134,6 +134,7 @@ export const Storage = <const>{
 			},
 			canvas: {
 				timeZone: savedFields['timeZone'],
+				importMissingDueDates: savedFields['canvas.importMissingDueDates'],
 				courseCodeOverrides: JSON.parse(savedFields['canvas.courseCodeOverrides']),
 			},
 			notion: {

--- a/src/options/configuration.ts
+++ b/src/options/configuration.ts
@@ -4,6 +4,7 @@ import {
 	InputFieldValidator,
 	StringField,
 	RequiredStringField,
+	// TODO: remove unused
 	RequiredNumberAsStringField,
 	TimeZoneField,
 	RequiredNotionTokenField,
@@ -83,6 +84,9 @@ interface InputElements {
 	'options.displayAdvanced': 'display-advanced-options';
 	hideAdvancedOptions: 'hide-advanced-options';
 	showAdvancedOptions: 'show-advanced-options';
+	'canvas.importMissingDueDates': 'missing-due-dates';
+	ignoreMissingDueDates: 'ignore-missing-due-dates';
+	importMissingDueDates: 'import-missing-due-dates';
 	'canvas.courseCodeOverrides': 'course-code-overrides-group';
 	'notion.accessToken': 'notion-token';
 	'notion.databaseId': 'database-id';
@@ -207,6 +211,27 @@ export const CONFIGURATION: {
 			},
 		},
 		canvas: {
+			importMissingDueDates: {
+				defaultValue: false,
+				get input() {
+					delete (<Partial<typeof this>>this).input;
+					return this.input = SegmentedControl.getInstance<InputElementId, typeof this.defaultValue>({
+						id: 'missing-due-dates',
+						segments: [
+							{
+								id: 'ignore-missing-due-dates',
+								value: false,
+								default: true,
+							},
+							{
+								id: 'import-missing-due-dates',
+								value: true,
+								showDependents: true,
+							},
+						],
+					});
+				},
+			},
 			courseCodeOverrides: {
 				defaultValue: '{}',
 				get input() {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -76,7 +76,7 @@
     <h3 class='advanced-options hidden'>Extension Popup</h3>
     <div class='tile advanced-options hidden'>
       <div>
-        <label class=' required' for='display-json-button'>Display 'Copy <code>JSON</code>' button</label>
+        <label class='required' for='display-json-button'>Display 'Copy <code>JSON</code>' button</label>
         <div class='segmented-control-wrapper'>
           <div class='segmented-control row' id='display-json-button'>
             <input checked type='radio' name='display-json-button' value='hide-json-button' id='hide-json-button'>
@@ -92,9 +92,25 @@
 
 
   <section>
-    <h1 class='advanced-options hidden'>Canvas Configuration</h1>
+    <h1>Canvas Configuration</h1>
 
-    <h2 class='advanced-options hidden'>Course Code Overrides</h2>
+    <h3>Assignment Import</h3>
+    <div class='tile'>
+      <div>
+        <label class='required' for='missing-due-dates'>Assignments without due dates</label>
+        <div class='segmented-control-wrapper'>
+          <div class='segmented-control row' id='missing-due-dates'>
+            <input type='radio' name='missing-due-dates' value='ignore-missing-due-dates' id='ignore-missing-due-dates'>
+            <label for='ignore-missing-due-dates'>Ignore</label>
+
+            <input type='radio' name='missing-due-dates' value='import-missing-due-dates' id='import-missing-due-dates'>
+            <label for='import-missing-due-dates'>Import</label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h3 class='advanced-options hidden'>Course Code Overrides</h3>
     <div class='tile advanced-options hidden'>
       <div id='course-code-overrides-group' class='row'>
         <div>

--- a/src/popup/fetch.ts
+++ b/src/popup/fetch.ts
@@ -54,8 +54,8 @@ function roundToNextHour(date: Date): Date {
 		const emojiedCourseCode = `${(courseIcon) ? `${courseIcon} ` : ''}${courseCode}`;
 
 		// TODO: sort by due date
-		// TODO: filer !due_at
 		const canvasAssignments = assignmentGroups.flatMap(group => group.assignments)
+			.filter(assignment => options.canvas.importMissingDueDates || assignment.due_at)
 			.map(assignment => ({
 				name: assignment.name,
 				description: assignment.description,

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -9,6 +9,7 @@ interface RequiredFields {
 	'extension.displayTheme': null | 'light' | 'dark';
 	'popup.displayJSONButton': boolean;
 	'options.displayAdvanced': boolean;
+	'canvas.importMissingDueDates': boolean;
 	'notion.accessToken': NullIfEmpty<string>;
 	'notion.databaseId': NullIfEmpty<string>;
 	'notion.propertyNames.name': NeverEmpty<string>;
@@ -48,6 +49,7 @@ export type SavedOptions = {
 		displayAdvanced: RequiredFields['options.displayAdvanced'];
 	};
 	canvas: {
+		importMissingDueDates: RequiredFields['canvas.importMissingDueDates'];
 		courseCodeOverrides: OptionalFields['canvas.courseCodeOverrides'];
 	},
 	notion: {


### PR DESCRIPTION
Adds the ability to either import all assignments, even if they're missing a `due_at` date, or to only import assignments with due dates.

![image](https://user-images.githubusercontent.com/44986932/179973727-3f8bbc5a-c59f-46f5-81ae-7f8dbc8f93cd.png)
