### PR TITLE
Import `points` property of Canvas assignment to Notion

### DIFF
--- a/src/apis/storage.ts
+++ b/src/apis/storage.ts
@@ -146,6 +146,7 @@ export const Storage = <const>{
 					category: savedFields['notion.propertyNames.category'],
 					course: savedFields['notion.propertyNames.course'],
 					url: savedFields['notion.propertyNames.url'],
+					points: savedFields['notion.propertyNames.points'],
 					available: savedFields['notion.propertyNames.available'],
 					due: savedFields['notion.propertyNames.due'],
 					span: savedFields['notion.propertyNames.span'],

--- a/src/options/configuration.ts
+++ b/src/options/configuration.ts
@@ -93,6 +93,7 @@ interface InputElements {
 	'notion.propertyNames.category': 'notion-property-category';
 	'notion.propertyNames.course': 'notion-property-course';
 	'notion.propertyNames.url': 'notion-property-url';
+	'notion.propertyNames.points': 'notion-property-points';
 	'notion.propertyNames.available': 'notion-property-available';
 	'notion.propertyNames.due': 'notion-property-due';
 	'notion.propertyNames.span': 'notion-property-span';
@@ -269,6 +270,7 @@ export const CONFIGURATION: {
 					'notion-property-category',
 					'notion-property-course',
 					'notion-property-url',
+					'notion-property-points',
 					'notion-property-available',
 					'notion-property-due',
 					'notion-property-span',
@@ -313,6 +315,16 @@ export const CONFIGURATION: {
 						delete (<Partial<typeof this>>this).input;
 						return this.input = Input.getInstance<InputElementId>({
 							id: 'notion-property-url',
+							Validator: StringField,
+						});
+					},
+				},
+				points: {
+					defaultValue: 'Points',
+					get input() {
+						delete (<Partial<typeof this>>this).input;
+						return this.input = Input.getInstance<InputElementId>({
+							id: 'notion-property-points',
 							Validator: StringField,
 						});
 					},

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -180,6 +180,11 @@
       </div>
 
       <div class='hidden'>
+        <label for='notion-property-points'>Points property (<a target='_blank' href='https://www.notion.so/help/database-properties'><code>Number</code></a>)</label>
+        <select id='notion-property-points' name='notion-property-points' class='row'></select>
+      </div>
+
+      <div class='hidden'>
         <label for='notion-property-available'>Unlock date property (<a target='_blank' href='https://www.notion.so/help/database-properties'><code>Date</code></a>)</label>
         <select id='notion-property-available' name='notion-property-available' class='row'></select>
       </div>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -35,6 +35,7 @@ interface OptionsElements {
 		categoryProperty: 'notion-property-category';
 		courseProperty: 'notion-property-course';
 		urlProperty: 'notion-property-url';
+		pointsProperty: 'notion-property-points';
 		availableProperty: 'notion-property-available';
 		dueProperty: 'notion-property-due';
 		spanProperty: 'notion-property-span';
@@ -163,6 +164,12 @@ const DatabaseSelect = <const>{
 			Validator: StringField,
 			fieldKey: 'notion.propertyNames.url',
 		}),
+		points: PropertySelect.getInstance<OptionsSelectId>({
+			id: 'notion-property-points',
+			type: 'number',
+			Validator: StringField,
+			fieldKey: 'notion.propertyNames.points',
+		}),
 		available: PropertySelect.getInstance<OptionsSelectId>({
 			id: 'notion-property-available',
 			type: 'date',
@@ -265,6 +272,7 @@ const buttons: {
 				'notion.propertyNames.category',
 				'notion.propertyNames.course',
 				'notion.propertyNames.url',
+				'notion.propertyNames.points',
 				'notion.propertyNames.available',
 				'notion.propertyNames.due',
 				'notion.propertyNames.span',

--- a/src/popup/fetch.ts
+++ b/src/popup/fetch.ts
@@ -63,7 +63,6 @@ function roundToNextHour(date: Date): Date {
 			.map(assignment => ({
 				name: assignment.name,
 				description: assignment.description,
-				// TODO(main): normalise this as a percentage of total points?
 				points: assignment.points_possible,
 				course: courseCode,
 				icon: courseIcon,

--- a/src/popup/import.ts
+++ b/src/popup/import.ts
@@ -85,6 +85,9 @@ export async function exportToNotion(): Promise<void | IFetchedAssignment[]> {
 				[options.propertyNames.url ?? EMPTY_PROPERTY]: {
 					url: this.url,
 				},
+				[options.propertyNames.points ?? EMPTY_PROPERTY]: {
+					number: this.points ?? 0,
+				},
 				[options.propertyNames.available ?? EMPTY_PROPERTY]: {
 					date: {
 						start: this.available,

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -21,6 +21,7 @@ interface OptionalFields {
 	'notion.propertyNames.category': NullIfEmpty<string>;
 	'notion.propertyNames.course': NullIfEmpty<string>;
 	'notion.propertyNames.url': NullIfEmpty<string>;
+	'notion.propertyNames.points': NullIfEmpty<string>;
 	'notion.propertyNames.available': NullIfEmpty<string>;
 	'notion.propertyNames.due': NullIfEmpty<string>;
 	'notion.propertyNames.span': NullIfEmpty<string>;
@@ -60,6 +61,7 @@ export type SavedOptions = {
 			category: OptionalFields['notion.propertyNames.category'];
 			course: OptionalFields['notion.propertyNames.course'];
 			url: OptionalFields['notion.propertyNames.url'];
+			points: OptionalFields['notion.propertyNames.points'];
 			available: OptionalFields['notion.propertyNames.available'];
 			due: OptionalFields['notion.propertyNames.due'];
 			span: OptionalFields['notion.propertyNames.span'];


### PR DESCRIPTION
Imports each Canvas assignment's `points` property to a configurable Notion database `number` property.

## Screenshots

### Configurable Option

![image](https://user-images.githubusercontent.com/44986932/179994845-130d8125-b7ab-4f8b-a0ab-a372c5f1b012.png)

### Imported Assignment

![image](https://user-images.githubusercontent.com/44986932/179995350-f9aed3ce-786c-40d5-9f0f-a42715bce631.png)

![image](https://user-images.githubusercontent.com/44986932/179995052-25507f57-2c02-4b1f-a54d-65956f89a3a8.png)
