### PR TITLE
Fix timezone issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@notionhq/client": "^1.0.4",
         "@tryfabric/martian": "^1.2.4",
+        "moment-timezone": "^0.5.37",
         "path-browserify": "^1.0.1",
         "turndown": "^7.1.1",
         "url-polyfill": "^1.1.12"
@@ -6964,6 +6965,25 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
+      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -16076,6 +16096,19 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-timezone": {
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
+      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@notionhq/client": "^1.0.4",
     "@tryfabric/martian": "^1.2.4",
+    "moment-timezone": "^0.5.37",
     "path-browserify": "^1.0.1",
     "turndown": "^7.1.1",
     "url-polyfill": "^1.1.12"

--- a/src/popup/fetch.ts
+++ b/src/popup/fetch.ts
@@ -1,6 +1,7 @@
+import moment from 'moment-timezone';
+
 import { CanvasClient } from '../apis/canvas';
 import { Storage } from '../apis/storage';
-import moment from 'moment-timezone';
 
 import { EmojiRequest } from '../types/notion';
 
@@ -38,7 +39,7 @@ function reformatDate(dateString: string, timeZone: string | null): string {
 				  but it will result in the correct date being shown in Notion.
 	 */
 	const date = new Date(dateString);
-	const offset = moment.tz.zone(timeZone ?? 'Pacific/Auckland')?.utcOffset(date.valueOf()) ?? 0;
+	const offset = moment.tz.zone(timeZone ?? moment.tz.guess())?.utcOffset(date.valueOf()) ?? 0;
 	date.setMinutes(date.getMinutes() - offset);
 	return date.toISOString();
 }
@@ -84,7 +85,9 @@ function reformatDate(dateString: string, timeZone: string | null): string {
 				course: courseCode,
 				icon: courseIcon,
 				url: assignment.html_url,
-				available: assignment.unlock_at ? reformatDate(assignment.unlock_at, options.notion.timeZone) : reformatDate(roundToNextHour(timeNow).toISOString(), options.notion.timeZone),
+				available: (assignment.unlock_at)
+					? reformatDate(assignment.unlock_at, options.notion.timeZone)
+					: reformatDate(roundToNextHour(timeNow).toISOString(), options.notion.timeZone),
 				due: reformatDate(assignment.due_at, options.notion.timeZone),
 			}));
 

--- a/src/popup/fetch.ts
+++ b/src/popup/fetch.ts
@@ -82,8 +82,8 @@ function reformatDate(date_str: string): string {
 				course: courseCode,
 				icon: courseIcon,
 				url: assignment.html_url,
-				available: assignment.unlock_at ?? roundToNextHour(timeNow).toISOString(),
-				due: assignment.due_at,
+				available: assignment.unlock_at ? reformatDate(assignment.unlock_at) : reformatDate(roundToNextHour(timeNow).toISOString()),
+				due: reformatDate(assignment.due_at),
 			}));
 
 		const savedAssignments = await Storage.getSavedAssignments();

--- a/src/popup/fetch.ts
+++ b/src/popup/fetch.ts
@@ -26,7 +26,7 @@ function roundToNextHour(date: Date): Date {
 	return date;
 }
 
-function reformatDate(date_str: string): string {
+function reformatDate(dateString: string): string {
 	/*
 		Problem:  Notion does not convert times into the correct timezone,
 				  even when supplied a timezone, Notion will show the user the
@@ -36,7 +36,7 @@ function reformatDate(date_str: string): string {
 				  on the offset of the local machine. This is a misuse of ISO time/date strings,
 				  but it will result in the correct date being shown in Notion.
 	 */
-	const date = new Date(date_str);
+	const date = new Date(dateString);
 	date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
 	return date.toISOString();
 }

--- a/src/popup/fetch.ts
+++ b/src/popup/fetch.ts
@@ -75,19 +75,16 @@ function reformatDate(date_str: string): string {
 			.sort(({ due_at: a }, { due_at: b }) => {
 				return Date.parse(a ?? timeNow) - Date.parse(b ?? timeNow);
 			})
-			.map(assignment => {
-				console.log(assignment.due_at, 'TIMEZONE', options.notion.timeZone);
-				return ({
-					name: assignment.name,
-					description: assignment.description,
-					points: assignment.points_possible,
-					course: courseCode,
-					icon: courseIcon,
-					url: assignment.html_url,
-					available: assignment.unlock_at ? reformatDate(assignment.unlock_at) : reformatDate(roundToNextHour(timeNow).toISOString()),
-					due: reformatDate(assignment.due_at),
-				});
-			});
+			.map(assignment => ({
+				name: assignment.name,
+				description: assignment.description,
+				points: assignment.points_possible,
+				course: courseCode,
+				icon: courseIcon,
+				url: assignment.html_url,
+				available: assignment.unlock_at ?? roundToNextHour(timeNow).toISOString(),
+				due: assignment.due_at,
+			}));
 
 		const savedAssignments = await Storage.getSavedAssignments();
 


### PR DESCRIPTION
Reformatted date strings received from Canvas to account for a difference in timezone. This version will create a new ISO date string that considers the user's timezone, and forwards this new ISO time string to Notion, resulting in the correct time being presented to the user. This method uses the timezone that the machine is operating on. **So if the user provides a timezone different from the one they are in, for some reason, the time that will go into Notion will be in accordance with the timezone their machine is currently in (i.e. using JavaScript's Date functionality), not the timezone they have manually entered.**